### PR TITLE
Fix the spelling mistake in page heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,6 @@
     }
   </style>
   <body>
-    <h1 class="some-heading">GIT WORKFLOW WORKSHOW</h1>
+    <h1 class="page-heading">GIT WORKFLOW WORKSHOW</h1>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,6 @@
     }
   </style>
   <body>
-    <h1 class="some-heading">GIT WORKFLOW WORKSHOW</h1>
+    <h1 class="some-heading">GIT WORKFLOW WORKSHOP</h1>
   </body>
 </html>


### PR DESCRIPTION
Fix the spelling mistake in <h1> typo